### PR TITLE
Fixed verification oc version for oc Origin

### DIFF
--- a/ansible/helloworld-msa.yml
+++ b/ansible/helloworld-msa.yml
@@ -12,7 +12,7 @@
     - name: Verify oc version
       shell: "oc version"
       register: command_result
-      failed_when: "'oc v3.2' not in command_result.stdout"
+      failed_when: "'oc v3.2' and 'oc v1.2' not in command_result.stdout"
 
     - name: Create Workdir
       file:


### PR DESCRIPTION
oc version verification fails if oc Origin is used because it's v1.2.0
