### PR TITLE
fix copy/paste error in the jokolia setup command for the ola and api…

### DIFF
--- a/api-gateway.adoc
+++ b/api-gateway.adoc
@@ -34,7 +34,7 @@ $ oc expose service api-gateway
 ##### (Optional) Enable Jolokia and Readiness probe
 
 ----
-$ oc env dc/aloha AB_ENABLED=jolokia; oc patch dc/api-gateway -p '{"spec":{"template":{"spec":{"containers":[{"name":"api-gateway","ports":[{"containerPort": 8778,"name":"jolokia"}]}]}}}}'
+$ oc env dc/api-gateway AB_ENABLED=jolokia; oc patch dc/api-gateway -p '{"spec":{"template":{"spec":{"containers":[{"name":"api-gateway","ports":[{"containerPort": 8778,"name":"jolokia"}]}]}}}}'
 $ oc set probe dc/api-gateway --readiness --get-url=http://:8080/health
 ----
 

--- a/ola.adoc
+++ b/ola.adoc
@@ -31,7 +31,7 @@ $ oc expose service ola
 ##### (Optional) Enable Jolokia and Readiness probe
 
 ----
-$ oc env dc/aloha AB_ENABLED=jolokia; oc patch dc/ola -p '{"spec":{"template":{"spec":{"containers":[{"name":"ola","ports":[{"containerPort": 8778,"name":"jolokia"}]}]}}}}'
+$ oc env dc/ola AB_ENABLED=jolokia; oc patch dc/ola -p '{"spec":{"template":{"spec":{"containers":[{"name":"ola","ports":[{"containerPort": 8778,"name":"jolokia"}]}]}}}}'
 $ oc set probe dc/ola --readiness --get-url=http://:8080/api/health
 ----
 


### PR DESCRIPTION
…-gateway service


Looks like there was a possible copy/paste error in the Jokolia commands for the ola service and the api-gateway service.

@rafabene ^
